### PR TITLE
Emit event when datatable was created; That needed in other parent directives for example;

### DIFF
--- a/src/angular-datatables.directive.js
+++ b/src/angular-datatables.directive.js
@@ -16,11 +16,12 @@
             $elem.show();
             $loading.hide();
         };
-        var _doRenderDataTable = function($elem, options) {
+        var _doRenderDataTable = function($elem, options, $scope) {
             // Add $timeout to be sure that angular has finished rendering before calling datatables
             $timeout(function() {
                 _hideLoading($elem);
                 $elem.DataTable(options);
+                $scope.$emit('event:dataTableLoaded', { id: $elem.attr('id') });
             }, 0, false);
         };
 
@@ -53,7 +54,7 @@
             return {
                 options: options,
                 render: function ($scope, $elem) {
-                    _doRenderDataTable($elem, this.options);
+                    _doRenderDataTable($elem, this.options, $scope);
                 }
             };
         };
@@ -70,7 +71,7 @@
                 render: function ($scope, $elem) {
                     var _this = this;
                     $scope.$on(DT_LAST_ROW_KEY, function () {
-                        _doRenderDataTable($elem, _this.options);
+                        _doRenderDataTable($elem, _this.options, $scope);
                     });
                 }
             };


### PR DESCRIPTION
Hi!

I forked your repository for adding small feature. I suggest throwing event with table Id when dataTable was created. It gives a lot of help for tracking it in another directive. It needed to predefine some columns and options which I will use for many tables.

For example:

I created some directive with template:

`<table class="jq-table table table-bordered table-striped" datatable dt-options="tableOptions" dt-columns="tableColumns"></table>`

And I would like to get access to dataTable element. With that event I can get table element by Id from event arguments.

If you accept my changes, Can you increase version of your release, please?

Many thanks!

---

Regards, Ivan
