### PR TITLE
Re-instantiation bug when updating $scope

### DIFF
--- a/src/angular-datatables.directive.js
+++ b/src/angular-datatables.directive.js
@@ -16,6 +16,11 @@
                 $elem.show();
                 $loading.hide();
             }, _renderDataTableAndEmitEvent = function ($elem, options, $scope) {
+                var tableId = '#' + $elem.attr('id');
+                if($.fn.dataTable.isDataTable( tableId )) {
+                    return $(tableId).DataTable();
+                }
+                
                 var oTable = $elem.DataTable(options);
                 $scope.$emit('event:dataTableLoaded', { id: $elem.attr('id') });
                 return oTable;


### PR DESCRIPTION
When using "The angular way" to create and render a table then you build the `<tr>` rows like so:

```
<tr ng-repeat="user in users">
  <td>{{ id }}</td>
  <td>{{ id }}</td>
</tr>
```

If you want to bind new data to `$scope.users` then an error occurs saying that DataTables is already instantiated.

The solution is to check if the table doesn't already exist and if so, then return the existing DataTable instance.

This commit fixes that bug.
