### PR TITLE
Fix issue #78 - "The regex in NGRenderer's render method is wrong"

### DIFF
--- a/src/angular-datatables.renderer.js
+++ b/src/angular-datatables.renderer.js
@@ -62,7 +62,7 @@
                         expression = $elem.find('tbody').html(),
                         // Find the resources from the comment <!-- ngRepeat: item in items --> displayed by angular in the DOM
                         // This regexp is inspired by the one used in the "ngRepeat" directive
-                        match = expression.match(/^\s*.+\s+in\s+(\w*)\s*/),
+                        match = expression.match(/^\s*.+\s+in\s+(\S*)\s*/),
                         ngRepeatAttr = match[1];
 
                     if (!match) {


### PR DESCRIPTION
issue #78 fix.

The modified regex should match the whole word describing the data source, even when it includes dots, special characters and etc.
