### PR TITLE
FIX regexp

### DIFF
--- a/src/angular-datatables.renderer.js
+++ b/src/angular-datatables.renderer.js
@@ -53,7 +53,7 @@
                         expression = $elem.find('tbody').html(),
                         // Find the resources from the comment <!-- ngRepeat: item in items --> displayed by angular in the DOM
                         // This regexp is inspired by the one used in the "ngRepeat" directive
-                        match = expression.match(/^\s*.+\s+in\s+(\S*)\s*/),
+                        match = expression.match(/^\s*.+?\s+in\s+(\S*)\s*/),
                         ngRepeatAttr = match[1];
 
                     if (!match) {


### PR DESCRIPTION
The regexp being used fails if the datatable is not initialised with empty data.

When the table is empty, we try to match an expression that looks like this :
`<!-- ngRepeat: v in a.b --><!-- end ngRepeat: v in a.b -->`

ngRepeatAttr is then correctly matched to `a.b`

When the table is NOT empty, then the expression looks more like this :
`<!-- ngRepeat: v in a.b --><tr ng-repeat="v in a.b" class="ng-scope">...`

ngRepeatAttr is then set to `a.b"` (with a quote at the end of the expression)

We should use a `.+?` as a non-greedy version of `.+` to match only the expression inside the comment
