### PR TITLE
Enable regexp to find ngRepeat comment in multiple lines

### DIFF
--- a/src/angular-datatables.renderer.js
+++ b/src/angular-datatables.renderer.js
@@ -173,12 +173,12 @@ function dtNGRenderer($log, $q, $compile, $timeout, DTRenderer, DTRendererServic
             var _expression = $elem.find('tbody').html();
             // Find the resources from the comment <!-- ngRepeat: item in items --> displayed by angular in the DOM
             // This regexp is inspired by the one used in the "ngRepeat" directive
-            var _match = _expression.match(/^\s*.+?\s+in\s+(\S*)\s*/);
-            var _ngRepeatAttr = _match[1];
+            var _match = _expression.match(/^\s*.+?\s+in\s+(\S*)\s*/m);
 
             if (!_match) {
                 throw new Error('Expected expression in form of "_item_ in _collection_[ track by _id_]" but got "{0}".', _expression);
             }
+            var _ngRepeatAttr = _match[1];
 
             var _alreadyRendered = false;
 


### PR DESCRIPTION
Enable regexp to find ngRepeat comment in multiple lines

Display error at the right time