### PR TITLE
Adding option for prevent redraw table after row was added

### DIFF
--- a/src/angular-datatables.renderer.js
+++ b/src/angular-datatables.renderer.js
@@ -339,7 +339,7 @@ function dtPromiseRenderer($q, $timeout, $log, DTRenderer, DTRendererService, DT
 
         function _redrawRows() {
             _oTable.clear();
-            _oTable.rows.add(options.aaData).draw();
+            _oTable.rows.add(options.aaData).draw(options.redraw);
             return {
                 id: dtInstance.id,
                 DataTable: dtInstance.DataTable,


### PR DESCRIPTION
Take advantages of http://datatables.net/reference/api/draw(). We should have option to not change page after row was added. We can use it like this .withOption('redraw', false);