### PR TITLE
strip malformed character causing syntax error in Chrome, Firefox

### DIFF
--- a/dist/angular-datatables.js
+++ b/dist/angular-datatables.js
@@ -380,7 +380,7 @@ function dtColumnBuilder() {
             }
             var column = Object.create(DTColumn);
             column.mData = mData;
-            column.sTitle = sTitle ||  '';
+            column.sTitle = sTitle || '';
             return column;
         },
         DTColumn: DTColumn


### PR DESCRIPTION
Extra space that isn't a space, and causes both Firefox and Chrome to
abort loading and running script with a thrown SyntaxError.