### PR TITLE
Fix characters in angular-datatables.js

### DIFF
--- a/dist/angular-datatables.js
+++ b/dist/angular-datatables.js
@@ -972,10 +972,10 @@ function dtPromiseRenderer($q, $timeout, $log, DTRenderer, DTRendererService, DT
                 throw new Error('You must provide a promise or a function that returns a promise!');
             }
             if (_loadedPromise) {
-                _loadedPromise.then(function()  {
+                _loadedPromise.then(function(){
                     defer.resolve(_startLoading(fnPromise, callback));
                 });
-            } else  {
+            } else {
                 defer.resolve(_startLoading(fnPromise, callback));
             }
             return defer.promise;
@@ -1137,7 +1137,7 @@ function dtRendererFactory(DTDefaultRenderer, DTNGRenderer, DTPromiseRenderer, D
         fromOptions: fromOptions
     };
 
-    function fromOptions(options, isNgDisplay)  {
+    function fromOptions(options, isNgDisplay){
         if (isNgDisplay) {
             if (options && options.serverSide) {
                 throw new Error('You cannot use server side processing along with the Angular renderer!');


### PR DESCRIPTION
There were some odd characters floating around in the JavaScript file angular-datatables.js. I have removed these characters however the minified file will also be buggy. So please re-compile! The characters were found on lines 975, 978, and 1140. Cheers :)