### PR TITLE
Remove invisible characters in angular-datatables.renderer.js

### DIFF
--- a/src/angular-datatables.renderer.js
+++ b/src/angular-datatables.renderer.js
@@ -316,10 +316,10 @@ function dtPromiseRenderer($q, $timeout, $log, DTRenderer, DTRendererService, DT
                 throw new Error('You must provide a promise or a function that returns a promise!');
             }
             if (_loadedPromise) {
-                _loadedPromise.then(function()  {
+                _loadedPromise.then(function() {
                     defer.resolve(_startLoading(fnPromise, callback));
                 });
-            } else  {
+            } else {
                 defer.resolve(_startLoading(fnPromise, callback));
             }
             return defer.promise;
@@ -482,7 +482,7 @@ function dtRendererFactory(DTDefaultRenderer, DTNGRenderer, DTPromiseRenderer, D
         fromOptions: fromOptions
     };
 
-    function fromOptions(options, isNgDisplay)  {
+    function fromOptions(options, isNgDisplay) {
         if (isNgDisplay) {
             if (options && options.serverSide) {
                 throw new Error('You cannot use server side processing along with the Angular renderer!');


### PR DESCRIPTION
There are some invisible characters in the file that are causing troubles when building Docker image of AngularJS application using angular-datatables module.