### PR TITLE
Fix datatables dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "angular": ">=1.3.0",
-    "datatables": ">=1.10.9",
+    "datatables.net": ">=1.10.9",
     "jquery": ">=1.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
According to the upstream website of DataTables,
and the bower-based webjars for its plugins,
“datatables.net” is its official and correct
package name, not “datatables” which exists only
as a legacy alias (the content is identical, I checked).