### PR TITLE
Added $ to the ng-repeat directive comment regex

### DIFF
--- a/src/angular-datatables.renderer.js
+++ b/src/angular-datatables.renderer.js
@@ -176,7 +176,7 @@ function dtNGRenderer($log, $q, $compile, $timeout, DTRenderer, DTRendererServic
             var _expression = _$tableElem[1];
             // Find the resources from the comment <!-- ngRepeat: item in items --> displayed by angular in the DOM
             // This regexp is inspired by the one used in the "ngRepeat" directive
-            var _match = _expression.match(/^\s*.+?\s+in\s+([a-zA-Z0-9\.-_]*)\s*/m);
+            var _match = _expression.match(/^\s*.+?\s+in\s+([a-zA-Z0-9\.-_$]*)\s*/m);
 
             if (!_match) {
                 throw new Error('Expected expression in form of "_item_ in _collection_[ track by _id_]" but got "{0}".', _expression);


### PR DESCRIPTION
The regular expression searching for the `<!-- ngRepeat: item in items -->` comment directive was not matching correctly when the binding contained a `$`, like `item in $ctrl.items`.

This change adds the `$` to the matched symbols.