### PR TITLE
Update readme for Angular 1.x branch. [bower command update] 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ The files can be downloaded from:
 > The CSS file only contains `Twitter Bootstrap` styles to support datatables.
 
 **With Bower**
+This will install `angular-datatables` for Angular 1.X. For Angular 2 supported version, please navigate to https://github.com/l-lin/angular-datatables/ 
 
 ```
-bower install angular-datatables
+bower install angular-datatables#0.6.0
 ```
 
 ### Installation


### PR DESCRIPTION
`bower install` command in Angular 1.x branch was installing `angular-datatables` ^2.x versions.