### PR TITLE
Add missing dependency datatables.net-dt in bower for releases >=0.5.5;

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "angular": "~1.6.0",
     "datatables.net": ">=1.10.9",
+    "datatables.net-dt": ">=1.10.9",
     "jquery": ">=1.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!
I founded that bug, when tried zero configuration example with release **0.5.5** and **bower**;
With release 0.5.4 or NPM it's all ok!

**How to reproduce?**
1. bower i angular-datatables#0.5.5
2. Create code from example http://l-lin.github.io/angular-datatables/archives/#/zeroConfig
Add to index.html scripts and css:
- <script src="bower_components/jquery/dist/jquery.min.js"></script>
- <script src="bower_components/datatables.net/media/js/jquery.dataTables.min.js"></script>
- <script src="bower_components/angular/angular.min.js"></script>
- <script src="bower_components/angular-datatables/dist/angular-datatables.min.js"></script>
- <>link rel="stylesheet" href="bower_components/angular-datatables/dist/css/angular-datatables.css">

**Problem:**
Styles on table incorrect, missing jquery.dataTables.min.css styles.
It is important to add <link rel="stylesheet" href="bower_components/datatables.net-dt/media/css/jquery.dataTables.min.css"> on page.
BUT Missing datatables.net-dt/media/jquery.dataTables.min.css from dependencies.
 
**How to fix?**
- add to bower.json "datatables.net-dt": ">=1.10.9",


