### PR TITLE
Fix the Server Side the Angular way example

### DIFF
--- a/demo/src/app/basic/server-side-angular-way-snippet.component.ts
+++ b/demo/src/app/basic/server-side-angular-way-snippet.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'app-server-side-angular-way-snippet',
-    template: `
+  selector: 'app-server-side-angular-way-snippet',
+  template: `
   <div id="html" class="col s12 m9 l12">
     <h4 class="header">HTML</h4>
     <section [innerHTML]="htmlSnippet" highlight-js-content=".xml"></section>
@@ -18,105 +18,103 @@ import { Component } from '@angular/core';
   `
 })
 export class ServerSideAngularWaySnippetComponent {
-    htmlSnippet = `
+  htmlSnippet = `
 <pre>
 <code class="xml highlight">&lt;table datatable [dtOptions]="dtOptions" class="row-border hover"&gt;
-    &lt;thead&gt;
-        &lt;tr&gt;
-            &lt;th&gt;ID&lt;/th&gt;
-            &lt;th&gt;First name&lt;/th&gt;
-            &lt;th&gt;Last name&lt;/th&gt;
-        &lt;/tr&gt;
-    &lt;/thead&gt;
-    &lt;tbody&gt;
-        &lt;tr *ngFor="let person of persons"&gt;
-            &lt;td&gt;{{ person.id }}&lt;/td&gt;
-            &lt;td&gt;{{ person.firstName }}&lt;/td&gt;
-            &lt;td&gt;{{ person.lastName }}&lt;/td&gt;
-        &lt;/tr&gt;
-        &lt;tr *ngIf="persons?.length == 0"&gt;
-            &lt;td colspan="3" class="no-data-available"&gt;No data!&lt;/td&gt;
-        &lt;/tr&gt;
-    &lt;/tbody&gt;
+  &lt;thead&gt;
+    &lt;tr&gt;
+      &lt;th&gt;ID&lt;/th&gt;
+      &lt;th&gt;First name&lt;/th&gt;
+      &lt;th&gt;Last name&lt;/th&gt;
+    &lt;/tr&gt;
+  &lt;/thead&gt;
+  &lt;tbody&gt;
+    &lt;tr *ngFor="let person of persons"&gt;
+      &lt;td&gt;{{ person.id }}&lt;/td&gt;
+      &lt;td&gt;{{ person.firstName }}&lt;/td&gt;
+      &lt;td&gt;{{ person.lastName }}&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr *ngIf="persons?.length == 0"&gt;
+      &lt;td colspan="3" class="no-data-available"&gt;No data!&lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/tbody&gt;
 &lt;/table&gt;</code>
 </pre>
   `;
 
-    cssSnippet = `
+  cssSnippet = `
 <pre>
 <code class="css highlight">/*
    server-side-angular-way.component.css
 */
 .no-data-available {
-    text-align: center;
+  text-align: center;
 }
 
 /*
    src/styles.css (i.e. your global style)
 */
 .dataTables_empty {
-    display: none;
+  display: none;
 }</code>
 </pre>
-    `;
+  `;
 
-    tsSnippet = `
+  tsSnippet = `
 <pre>
 <code class="typescript highlight">import { Component, OnInit } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 
 class Person {
-    id: number;
-    firstName: string;
-    lastName: string;
+  id: number;
+  firstName: string;
+  lastName: string;
 }
 
 class DataTablesResponse {
-    data: any[];
-    draw: number;
-    recordsFiltered: number;
-    recordsTotal: number;
+  data: any[];
+  draw: number;
+  recordsFiltered: number;
+  recordsTotal: number;
 }
 
 @Component({
-    selector: 'app-server-side-angular-way',
-    templateUrl: 'server-side-angular-way.component.html',
-    styleUrls: ['server-side-angular-way.component.css']
+  selector: 'app-server-side-angular-way',
+  templateUrl: 'server-side-angular-way.component.html',
+  styleUrls: ['server-side-angular-way.component.css']
 })
 export class ServerSideAngularWayComponent implements OnInit {
-    dtOptions: DataTables.Settings = {};
-    persons: Person[] = [];
+  dtOptions: DataTables.Settings = {};
+  persons: Person[];
 
-    constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
-    ngOnInit(): void {
-        const that = this;
+  ngOnInit(): void {
+    const that = this;
 
-        this.dtOptions = {
-            pagingType: 'full_numbers',
-            pageLength: 2,
-            serverSide: true,
-            processing: true,
-            ajax: (dataTablesParameters: any, callback) =&gt; {
-              that.http
-                  .post&lt;DataTablesResponse&gt;(
-                    'https://angular-datatables-demo-server.herokuapp.com/',
-                    dataTablesParameters, {})
-                  .subscribe(resp =&gt; {
-                      that.persons = resp.data;
+    this.dtOptions = {
+      pagingType: 'full_numbers',
+      pageLength: 2,
+      serverSide: true,
+      processing: true,
+      ajax: (dataTablesParameters: any, callback) =&gt; {
+        that.http
+          .post&lt;DataTablesResponse&gt;(
+            'https://angular-datatables-demo-server.herokuapp.com/',
+            dataTablesParameters, {}
+          ).subscribe(resp =&gt; {
+            that.persons = resp.data;
 
-                      callback({
-                          recordsTotal: resp.recordsTotal,
-                          recordsFiltered: resp.recordsFiltered,
-                          data: [],
-                      });
-                  });
-            },
-            columns: [
-                { data: 'id' }, { data: 'firstName' }, { data: 'lastName' },
-            ],
-        };
-    }
+            callback({
+              recordsTotal: resp.recordsTotal,
+              recordsFiltered: resp.recordsFiltered,
+              data: []
+            });
+          });
+      },
+      columns: [{ data: 'id' }, { data: 'firstName' }, { data: 'lastName' }]
+    };
+  }
 }</code>
 </pre>
   `;

--- a/demo/src/app/basic/server-side-angular-way.component.ts
+++ b/demo/src/app/basic/server-side-angular-way.component.ts
@@ -21,7 +21,7 @@ class DataTablesResponse {
 })
 export class ServerSideAngularWayComponent implements OnInit {
   dtOptions: DataTables.Settings = {};
-  persons: Person[] = [];
+  persons: Person[];
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
Fixes a bug where the table won't display the "No data!" message when the API returns an empty array in the very first call. This happens because the `this.persons` array is already initialized with an empty array within the class, so it's not updated when it receives another empty array from the API. The table gets overwritten by DataTables and erases the "no data" message.

Also fixes the indentation on snippets to match the 2 spaces used throughout the project.