### PR TITLE
Update angular version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -50,7 +50,7 @@
     "dtColumns.json"
   ],
   "dependencies": {
-    "angular": "~1.6.0",
+    "angular": "~1.7.0",
     "datatables.net": ">=1.10.9",
     "datatables.net-dt": ">=1.10.9",
     "jquery": ">=1.11.0"


### PR DESCRIPTION
I have observed no issues related to angular-datatables in our project when updating angularJS version to that of 1.7.2. Having the current version set to ~1.6.0 makes bower complain.

Do tell me if I need to do something more before this can be accepted.

 