### PR TITLE
Fix for #1299: Ugly Re-render in Angular "ng" mode.

### DIFF
--- a/src/angular-datatables.renderer.js
+++ b/src/angular-datatables.renderer.js
@@ -185,6 +185,7 @@ function dtNGRenderer($log, $q, $compile, $timeout, DTRenderer, DTRendererServic
 
             _parentScope.$watchCollection(_ngRepeatAttr, function() {
                 if (_oTable) {
+                    DTRendererService.showLoading(_$elem, _parentScope);
                     _destroyAndCompile();
                 }
                 $timeout(function() {


### PR DESCRIPTION
Change: angular-datatables show the 'loading' template just before the table gets destroyed.
