### PR TITLE
build(#1505): add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run build
+        run: npm run build
+
+      - name: Publish to NPM packages
+        # includes a --ignore-scripts command argument to avoid executing npm life cycle scripts during this phase
+        # for security concerns as scripts could steal NODE_AUTH_TOKEN
+        run: npm publish --ignore-scripts --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -108,6 +108,18 @@ You may need to have the following:
 ```sh
 # this will create a new version and push to remote repository
 npm version [<newversion> | major | minor | patch]
+
+# examples
+# create a patch version to publish fixes to the package
+npm version patch
+# provide a commit message ('%s' will be replaced by the version number)
+npm version patch -m "chore: release %s"
+# create a minor version to publish new features
+npm version minor
+# create a major version to follow Angular major version
+npm version major
+# more control to the version to set
+npm version 8.3.2
 ```
 
 Then go to the [release page](https://github.com/l-lin/angular-datatables/releases) and manually

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -105,26 +105,14 @@ You may need to have the following:
 
 ## Release
 
-```bash
-# update version on package.json files
-sed -i 's/"version": "\(.\+\)-dev",/"version": "\1",/g' package.json
-sed -i 's/"version": "\(.\+\)-dev",/"version": "\1",/g' demo/package.json
-# update the version for schematics in file 'schematics/src/ng-add/index.ts'
-# build
-npm run build
-# commit
-git add -A && git commit -m "chore: release vX.Y.Z"
-git tag vX.Y.Z
-git push && git push --tags
-# publish
-npm publish
-
-# don't forget to set the next iteration by editing the files:
-# - package.json
-# - demo/package.json
-git add -A && git commit -m "chore: prepare next iteration vX.Y.Z-dev"
-git push
+```sh
+# this will create a new version and push to remote repository
+npm version [<newversion> | major | minor | patch]
 ```
+
+Then go to the [release page](https://github.com/l-lin/angular-datatables/releases) and manually
+create a new release. There is an automatic [Github action](./.github/workflows/publish.yml) that
+publishes automatically to NPM repository.
 
 # Angular Schematics
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
     "lint:code": "tslint ./src/**/*.ts -t verbose --exclude ./src/**/*.d.ts",
     "lint:test": "tslint ./test/**/*.ts -t verbose --exclude ./test/**/*.d.ts",
     "rollup": "rollup -c rollup.conf.js",
-    "rollup:min": "rollup -c rollup-uglify.conf.js"
+    "rollup:min": "rollup -c rollup-uglify.conf.js",
+    "version": "npm run build && git add -A",
+    "postversion": "git push && git push --tags"
   },
   "keywords": [
     "Angular",
     "DataTables"
   ],
-  "author": "Louis LIN <louis.lin.87@gmail.com> (https://l-lin.github.io/)",
+  "author": "Louis LIN <lin.louis@pm.me> (https://l-lin.github.io/)",
   "contributors": [
     "Michael Bennett <michael@strukt.org>",
     "Steven Masala <me@smasalai.com>",


### PR DESCRIPTION
After some thoughts, it's not a must to set the version `x.y.z-dev` since it's not published in NPM.

It's also not mandatory to update the demo version as it's not used on NPM packages or anything else.