### PR TITLE
[Feature] Angular Schematics update

### DIFF
--- a/schematics/src/ng-add/index.ts
+++ b/schematics/src/ng-add/index.ts
@@ -23,8 +23,12 @@ function addPackageJsonDependencies() {
     ];
 
     dependencies.forEach(dependency => {
-      addPackageToPackageJson(tree, dependency.name, dependency.version, dependency.isDev);
-      context.logger.log('info', `✅️ Added "${dependency.name}" into "${dependency.isDev ? 'devDependencies' : 'dependencies' }"`);
+      const result = addPackageToPackageJson(tree, dependency.name, dependency.version, dependency.isDev);
+      if (result) {
+        context.logger.log('info', `✅️ Added "${dependency.name}" into "${dependency.isDev ? 'devDependencies' : 'dependencies'}"`);
+      } else {
+        context.logger.log('info', `ℹ️  Skipped adding "${dependency.name}" into package.json`);
+      }
     });
     return tree;
   };

--- a/schematics/src/ng-add/models/schematics-options.ts
+++ b/schematics/src/ng-add/models/schematics-options.ts
@@ -1,0 +1,6 @@
+import { ADTStyleOptions } from "./style-options";
+
+export interface IADTSchematicsOptions {
+  project: string,
+  style: ADTStyleOptions
+}

--- a/schematics/src/ng-add/models/style-options.ts
+++ b/schematics/src/ng-add/models/style-options.ts
@@ -1,0 +1,37 @@
+export enum ADTStyleOptions {
+  DT="dt",
+  BS3="bs3",
+  BS4="bs4",
+}
+
+export const ADT_SUPPORTED_STYLES = [
+  {
+    style: ADTStyleOptions.DT,
+    packageJson: [
+      { version: '^1.10.20', name: 'datatables.net-dt', isDev: false },
+    ],
+    angularJson: [
+      { path: 'node_modules/datatables.net-dt/css/jquery.dataTables.css', target: 'styles', fancyName: 'DataTables.net Core CSS' },
+    ]
+  },
+  {
+    style: ADTStyleOptions.BS3,
+    packageJson: [
+      { version: '^1.10.20', name: 'datatables.net-bs', isDev: false },
+    ],
+    angularJson: [
+      { path: 'node_modules/datatables.net-bs/css/dataTables.bootstrap.min.css', target: 'styles', fancyName: 'DataTables.net Bootstrap 3 CSS' },
+      { path: 'node_modules/datatables.net-bs/js/dataTables.bootstrap.min.js', target: 'scripts', fancyName: 'DataTables.net Bootstrap 3 JS' },
+    ]
+  },
+  {
+    style: ADTStyleOptions.BS4,
+    packageJson: [
+      { version: '^1.10.20', name: 'datatables.net-bs4', isDev: false },
+    ],
+    angularJson: [
+      { path: 'node_modules/datatables.net-bs4/css/dataTables.bootstrap4.min.css', target: 'styles', fancyName: 'DataTables.net Bootstrap 4 CSS' },
+      { path: 'node_modules/datatables.net-bs4/js/dataTables.bootstrap4.min.js', target: 'scripts', fancyName: 'DataTables.net Bootstrap 4 JS' },
+    ]
+  },
+]

--- a/schematics/src/ng-add/schema.json
+++ b/schematics/src/ng-add/schema.json
@@ -11,6 +11,27 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "style": {
+      "description": "The styling library to use for Datatables.",
+      "type": "string",
+      "default": "dt",
+      "enum": ["dt", "bs3", "bs4"],
+      "x-prompt": {
+        "message": "Which styling library would you like to use for DataTables?",
+        "type": "list",
+        "items": [
+          { "value": "dt", "label": "DataTables (Default)" },
+          {
+            "value": "bs3",
+            "label": "Bootstrap 3"
+          },
+          {
+            "value": "bs4",
+            "label": "Bootstrap 4"
+          }
+        ]
+      }
     }
   }
 }

--- a/schematics/src/ng-add/utils/index.ts
+++ b/schematics/src/ng-add/utils/index.ts
@@ -134,6 +134,30 @@ export function addPackageToPackageJson(host: Tree, pkg: string, version: string
   return false;
 }
 
+export function addAssetToAngularJson(host: Tree, assetType: string, assetPath: string): boolean {
+  /* tslint:disable-next-line: no-non-null-assertion */
+  const sourceText = host.read('angular.json')!.toString('utf-8');
+  const json = JSON.parse(sourceText);
+
+  if (!json) return false;
+
+  const projectName = Object.keys(json['projects'])[0];
+  const projectObject = json.projects[projectName];
+  const targets = projectObject.targets || projectObject.architect;
+
+  const targetLocation: string[] = targets.build.options[assetType];
+
+  // update UI that `assetPath` wasn't re-added to angular.json
+  if (targetLocation.indexOf(assetPath) != -1) return false;
+
+  targetLocation.push(assetPath);
+
+  host.overwrite('angular.json', JSON.stringify(json, null, 2));
+
+  return true;
+
+}
+
 export function removePackageJsonDependency(tree: Tree, dependencyName: string) {
   const packageContent = JSON.parse(getFileContent(tree, '/package.json'));
   delete packageContent.dependencies[dependencyName];

--- a/schematics/src/ng-add/utils/index.ts
+++ b/schematics/src/ng-add/utils/index.ts
@@ -27,7 +27,7 @@ export function installPackageJsonDependencies(): Rule {
 }
 
 export function addStyleToTarget(project: WorkspaceProject, targetName: string, host: Tree,
-                                 assetPath: string, workspace: WorkspaceSchema) {
+  assetPath: string, workspace: WorkspaceSchema) {
 
   const targetOptions = getProjectTargetOptions(project, targetName);
 
@@ -99,7 +99,7 @@ function sortObjectByKeys(obj: { [key: string]: string }) {
  * Note: This function accepts an additional parameter `isDevDependency` so we
  * can place a given dependency in the correct dependencies array inside package.json
  */
-export function addPackageToPackageJson(host: Tree, pkg: string, version: string, isDevDependency = false): Tree {
+export function addPackageToPackageJson(host: Tree, pkg: string, version: string, isDevDependency = false): boolean {
 
   if (host.exists('package.json')) {
     /* tslint:disable-next-line: no-non-null-assertion */
@@ -114,20 +114,24 @@ export function addPackageToPackageJson(host: Tree, pkg: string, version: string
       json.dependencies = {};
     }
 
+    // update UI that `pkg` wasn't re-added to package.json
+    if (json.dependencies[pkg] || json.devDependencies[pkg]) return false;
+
     if (!json.dependencies[pkg] && !isDevDependency) {
       json.dependencies[pkg] = version;
       json.dependencies = sortObjectByKeys(json.dependencies);
     }
 
-    if(!json.devDependencies[pkg] && isDevDependency) {
+    if (!json.devDependencies[pkg] && isDevDependency) {
       json.devDependencies[pkg] = version;
       json.devDependencies = sortObjectByKeys(json.devDependencies);
     }
 
     host.overwrite('package.json', JSON.stringify(json, null, 2));
+    return true;
   }
 
-  return host;
+  return false;
 }
 
 export function removePackageJsonDependency(tree: Tree, dependencyName: string) {


### PR DESCRIPTION
1. Fixes duplicate entries to `angular.json` when `ng add` is run several times.
2. Adds support for skipping modification to `angular.json` and `package.json` when not needed
3. Adds prompt for choosing styling library with `ng add`<sup>1</sup>.

<sup>1. The end-user needs to install and configure Bootstrap CSS on their project before installing this library for changes to take affect. </sup>