### PR TITLE
Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,12 +2,12 @@
 name: "\U0001F41E Bug report"
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: bug, needs-repro
 assignees: ''
 ---
 
 <!--
-Note: We offer assistance for Angular >=8 projects only. Do not open an issue if this is regarding AngularJS issue.
+Note: We offer assistance for Angular >=10 projects only. Do not open an issue if this is concering older Angular versions.
 -->
 
 # :beetle: bug report
@@ -16,40 +16,41 @@ A clear and concise description of what the bug is.
 
 ## :microscope: Minimal Reproduction
 
-<!--
-Please create and share minimal reproduction of the issue starting with this template: https://stackblitz.com/fork/angular-datatables-gitter
--->
+<!-- 
+Do not add source code here. The chances of fixing the issue would be higher if you provide a small, reproducible repo to investigate. 
+This is because, your source code will not include all the necessary bits that reproduce the issue. For example, you may have included source code for the Angular component that's causing the problem however you might have left out it's background Angular service which fetches/processes relevant data for the table OR your source code doesn't contain the JSON response object DataTables receives from your server which would mean we're missing context here.
 
-<!--
+Please create and share minimal reproduction of the issue starting with this template: https://stackblitz.com/fork/angular-datatables-gitter
+
 If StackBlitz is not suitable for reproduction of your issue, please create a minimal GitHub repository with the reproduction of the issue.
 A good way to make a minimal reproduction is to create a new app via `ng new repro-app` and add the minimum possible code to show the problem.
 Share the link to the repo below along with step-by-step instructions to reproduce the problem, as well as expected and actual behavior.
 
-Issues that don't have enough info and can't be reproduced will be closed.
+Issues that don't have enough info and can't be reproduced WILL be closed.
 
 You can read more about issue submission guidelines here: https://github.com/l-lin/angular-datatables/blob/master/.github/CONTRIBUTING.md#got-a-question-or-problem
+
 -->
 
+**StackBlitz/GitHub Link:**
+
+**Step-by-step Instructions:**
+
 ## :8ball: Expected behavior
-
-<pre><code>
-<!-- If the issue is accompanied by an exception or an error, please share it below: -->
-
-</code></pre>
 
 A clear and concise description of what you expected to happen.
 
 ## :camera: Screenshots
 
-<!-- If applicable, add screenshots to help explain your problem. -->
+<!-- Add screenshots to help explain your problem. -->
 
 ## :globe_with_meridians: Your Environment
 
-- node version: 
-- angular version: 
-- angular-cli version: 
-- jquery version: 
-- datatables version: 
+- NodeJS version: 
+- Angular version: 
+- Angular CLI version: 
+- jQuery version: 
+- DataTables version: 
 - angular-datatables version: 
 
 ## :memo: Additional context


### PR DESCRIPTION
- Set min Angular version to 10

- Include "needs-repro" label to all new bug reports

- Enforces StackBlitz/GitHub links instead of providing source code