### PR TITLE
chore(demo): switch angular-datatables-demo-server url #1672

### DIFF
--- a/demo/src/app/basic/server-side-angular-way.component.ts
+++ b/demo/src/app/basic/server-side-angular-way.component.ts
@@ -37,7 +37,7 @@ export class ServerSideAngularWayComponent implements OnInit {
       ajax: (dataTablesParameters: any, callback) => {
         that.http
           .post<DataTablesResponse>(
-            'https://angular-datatables-demo-server.herokuapp.com/',
+            'https://xtlncifojk.eu07.qoddiapp.com/',
             dataTablesParameters, {}
           ).subscribe(resp => {
             that.persons = resp.data;

--- a/demo/src/assets/docs/basic/server-side-angular-way/source-ts.md
+++ b/demo/src/assets/docs/basic/server-side-angular-way/source-ts.md
@@ -33,7 +33,7 @@ export class ServerSideAngularWayComponent implements OnInit {
       ajax: (dataTablesParameters: any, callback) => {
         that.http
           .post<DataTablesResponse>(
-            'https://angular-datatables-demo-server.herokuapp.com/',
+            'https://xtlncifojk.eu07.qoddiapp.com/',
             dataTablesParameters, {}
           ).subscribe(resp => {
             that.persons = resp.data;


### PR DESCRIPTION
Heroku has announced the [removal of free product plans on November 28, 2022](https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq).

An alternative platform was to use [quoddi](https://qoddi.com/).