### PR TITLE
fix(#1691/#1692): remove dep to codelyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,5 @@
     "url": "https://github.com/l-lin/angular-datatables/issues"
   },
   "homepage": "https://github.com/l-lin/angular-datatables#readme",
-  "dependencies": {
-    "codelyzer": "^6.0.2"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Should fix the issue on #1691 and #1692 as the codelyzer depends on angular 9, which may conflict with the project angular version. 