### PR TITLE
Fix ng pipe and TemplateRef for tables with invisible columns

### DIFF
--- a/src/angular-datatables.directive.ts
+++ b/src/angular-datatables.directive.ts
@@ -108,7 +108,7 @@ export class DataTableDirective implements OnDestroy, OnInit {
       const pipe = el.ngPipeInstance;
       const pipeArgs = el.ngPipeArgs || [];
       // find index of column using `data` attr
-      const i = columns.findIndex(e => e.data === el.data);
+      const i = columns.filter(c => c.visible !== false).findIndex(e => e.data === el.data);
       // get <td> element which holds data using index
       const rowFromCol = row.childNodes.item(i);
       // Transform data with Pipe and PipeArgs
@@ -125,7 +125,7 @@ export class DataTableDirective implements OnDestroy, OnInit {
     colsWithTemplate.forEach(el => {
       const { ref, context } = el.ngTemplateRef;
       // get <td> element which holds data using index
-      const i = columns.findIndex(e => e.data === el.data);
+      const i = columns.filter(c => c.visible !== false).findIndex(e => e.data === el.data);
       const cellFromIndex = row.childNodes.item(i);
       // reset cell before applying transform
       $(cellFromIndex).html('');


### PR DESCRIPTION
When applying Angular features like pipe and TemplateRef on a table with invisible columns, there is a discrepancy between the column definition and the resulting HTML. The library makes reference to the resulting HTML when modifying the table and assumes invisible columns are present in the DOM.

This proposed fix ensures that only visible columns are considered when deciding which column(s) to modify when applying pipe transforms or templates.